### PR TITLE
Don't validate mandatory / "Pflicht" fields

### DIFF
--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -16,7 +16,6 @@ type Reference struct {
 
 type Field struct {
 	Name       string     `yaml:"name"`
-	Mandatory  bool       `yaml:"mandatory"`
 	Index      bool       `yaml:"index"`
 	Xsd        string     `yaml:"xsd"`
 	Sqlite     string     `yaml:"sqlite"`

--- a/internal/sqlite.go
+++ b/internal/sqlite.go
@@ -62,7 +62,6 @@ create table "{{.Element}}" (
 	{{range .Fields -}}
 		"{{.Name}}"
 		{{- with .Sqlite}} {{.}}{{else}} text{{end}}
-		{{- /* {{- if .Mandatory}} not null{{end}} ["mandatory" fields are frequently missing] */ -}}
 		{{- with .References}} references "{{.Table}}"("{{.Column}}"){{end}},
 	{{end -}}
 	primary key ("{{.Primary}}")

--- a/spec/AnlagenEegBiomasse.yaml
+++ b/spec/AnlagenEegBiomasse.yaml
@@ -6,30 +6,24 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: Registrierungsdatum
     index: true
     xsd: date
     psql: date
-    mandatory: true # sometimes missing
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
-    mandatory: true
   - name: EegInbetriebnahmedatum
     index: true
     xsd: date
     psql: date
   - name: EegMaStRNummer
-    mandatory: true
   - name: AnlagenschluesselEeg
   - name: AnlagenkennzifferAnlagenregister
-    mandatory: true # sometimes missing
   - name: AnlagenkennzifferAnlagenregister_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: InstallierteLeistung
     index: true
     xsd: decimal
@@ -40,7 +34,6 @@ fields:
     psql: boolean
     sqlite: integer
   - name: AusschreibungZuschlag
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -71,31 +64,26 @@ fields:
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true # sometimes missing
   - name: BiogasGaserzeugungskapazitaet_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: BiogasHoechstbemessungsleistung
     xsd: decimal
     psql: real
     sqlite: real
   - name: BiomethanErstmaligerEinsatz
-    mandatory: true # sometimes missing
     xsd: date
     psql: date
   - name: BiomethanErstmaligerEinsatz_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: AnlageBetriebsstatus
     index: true
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id

--- a/spec/AnlagenEegGeoSolarthermieGrubenKlaerschlammDruckentspannung.yaml
+++ b/spec/AnlagenEegGeoSolarthermieGrubenKlaerschlammDruckentspannung.yaml
@@ -6,30 +6,24 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: Registrierungsdatum
     index: true
     xsd: date
     psql: date
-    mandatory: true # sometimes missing
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
-    mandatory: true
   - name: EegInbetriebnahmedatum
     index: true
     xsd: date
     psql: date
   - name: EegMastrNummer
-    mandatory: true
   - name: AnlagenschluesselEeg
   - name: AnlagenkennzifferAnlagenregister
-    mandatory: true # sometimes missing
   - name: AnlagenkennzifferAnlagenregister_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: InstallierteLeistung
     index: true
     xsd: decimal
@@ -40,10 +34,8 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
   - name: VerknuepfteEinheitenMaStRNummern
-    mandatory: true
 ---

--- a/spec/AnlagenEegSolar.yaml
+++ b/spec/AnlagenEegSolar.yaml
@@ -6,46 +6,38 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: Registrierungsdatum
     index: true
     xsd: date
     psql: date
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
-    mandatory: true
   - name: EegInbetriebnahmedatum
     index: true
     xsd: date
     psql: date
   - name: EegMaStRNummer
-    mandatory: true
   - name: InanspruchnahmeZahlungNachEeg
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: AnlagenschluesselEeg
   - name: AnlagenkennzifferAnlagenregister
-    mandatory: true # sometimes missing
   - name: AnlagenkennzifferAnlagenregister_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: InstallierteLeistung
     index: true
     xsd: decimal
     psql: real
     sqlite: real
   - name: RegistrierungsnummerPvMeldeportal
-    mandatory: true # sometimes missing
   - name: RegistrierungsnummerPvMeldeportal_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: MieterstromZugeordnet
     xsd: boolean
     psql: boolean
@@ -73,7 +65,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id

--- a/spec/AnlagenEegSpeicher.yaml
+++ b/spec/AnlagenEegSpeicher.yaml
@@ -6,21 +6,17 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: Registrierungsdatum
     index: true
     xsd: date
     psql: date
-    mandatory: true # sometimes missing
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
-    mandatory: true
   - name: EegInbetriebnahmedatum
     index: true
     xsd: date
     psql: date
   - name: EegMaStRNummer
-    mandatory: true
   - name: VerknuepfteEinheitenMaStRNummern
 ---

--- a/spec/AnlagenEegWasser.yaml
+++ b/spec/AnlagenEegWasser.yaml
@@ -6,30 +6,24 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: Registrierungsdatum
     index: true
     xsd: date
     psql: date
-    mandatory: true # sometimes missing
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
-    mandatory: true
   - name: EegInbetriebnahmedatum
     index: true
     xsd: date
     psql: date
   - name: EegMaStRNummer
-    mandatory: true
   - name: AnlagenschluesselEeg
   - name: AnlagenkennzifferAnlagenregister
-    mandatory: true # sometimes missing
   - name: AnlagenkennzifferAnlagenregister_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: InstallierteLeistung
     index: true
     xsd: decimal
@@ -40,7 +34,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id

--- a/spec/AnlagenEegWind.yaml
+++ b/spec/AnlagenEegWind.yaml
@@ -6,37 +6,29 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: Registrierungsdatum
     index: true
     xsd: date
     psql: date
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
-    mandatory: true
   - name: EegInbetriebnahmedatum
     index: true
     xsd: date
     psql: date
   - name: EegMaStRNummer
-    mandatory: true
   - name: AnlagenkennzifferAnlagenregister
-    mandatory: true # sometimes missing
   - name: AnlagenkennzifferAnlagenregister_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: AnlagenschluesselEeg
   - name: PrototypAnlage
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: PilotAnlage
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -46,47 +38,38 @@ fields:
     psql: real
     sqlite: real
   - name: VerhaeltnisErtragsschaetzungReferenzertrag
-    mandatory: true # sometimes missing
     xsd: decimal
     psql: real
     sqlite: real
   - name: VerhaeltnisErtragsschaetzungReferenzertrag_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: VerhaeltnisReferenzertragErtrag5Jahre
-    mandatory: true # sometimes missing
     xsd: decimal
     psql: real
     sqlite: real
   - name: VerhaeltnisReferenzertragErtrag5Jahre_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: VerhaeltnisReferenzertragErtrag10Jahre
-    mandatory: true # sometimes missing
     xsd: decimal
     psql: real
     sqlite: real
   - name: VerhaeltnisReferenzertragErtrag10Jahre_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: VerhaeltnisReferenzertragErtrag15Jahre
-    mandatory: true # sometimes missing
     xsd: decimal
     psql: real
     sqlite: real
   - name: VerhaeltnisReferenzertragErtrag15Jahre_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: AusschreibungZuschlag
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -96,7 +79,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id

--- a/spec/AnlagenGasSpeicher.yaml
+++ b/spec/AnlagenGasSpeicher.yaml
@@ -6,24 +6,18 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: MaStRNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: Speichername
-    mandatory: true
   - name: Registrierungsdatum
     index: true
     xsd: date
     psql: date
-    mandatory: true
   - name: AnlageBetriebsstatus
     index: true
-    mandatory: true
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer

--- a/spec/AnlagenKwk.yaml
+++ b/spec/AnlagenKwk.yaml
@@ -6,9 +6,7 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: KwkMastrNummer
-    mandatory: true
   - name: AusschreibungZuschlag
     xsd: boolean
     psql: boolean
@@ -19,14 +17,12 @@ fields:
     psql: timestamp
   - name: Inbetriebnahmedatum
     index: true
-    mandatory: true
     xsd: date
     psql: date
   - name: Registrierungsdatum
     index: true
     xsd: date
     psql: date
-    mandatory: true # sometimes missing
   - name: ThermischeNutzleistung
     index: true
     xsd: decimal
@@ -41,7 +37,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id

--- a/spec/AnlagenStromSpeicher.yaml
+++ b/spec/AnlagenStromSpeicher.yaml
@@ -6,18 +6,14 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: MaStRNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
-    mandatory: true
   - name: Registrierungsdatum
     index: true
     xsd: date
     psql: date
-    mandatory: true
   - name: NutzbareSpeicherkapazitaet
     index: true
     xsd: decimal
@@ -29,7 +25,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id

--- a/spec/Bilanzierungsgebiete.yaml
+++ b/spec/Bilanzierungsgebiete.yaml
@@ -7,19 +7,14 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: Id
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: Yeic
-    mandatory: true
   - name: BilanzierungsgebietNetzanschlusspunkt
-    mandatory: true
   - name: RegelzoneNetzanschlusspunkt
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
 ---

--- a/spec/EinheitenBiomasse.yaml
+++ b/spec/EinheitenBiomasse.yaml
@@ -6,16 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -23,7 +19,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
@@ -35,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -51,7 +45,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true # sometimes missing
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -60,9 +53,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -73,7 +64,6 @@ fields:
   - name: Adresszusatz
   - name: Ort
     index: true
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -97,7 +87,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -117,19 +106,14 @@ fields:
     xsd: date
     psql: date
   - name: NameStromerzeugungseinheit
-    mandatory: true
   - name: Weic
-    mandatory: true # sometimes missing
   - name: Weic_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: WeicDisplayName
   - name: Kraftwerksnummer
-    mandatory: true # sometimes missing
   - name: Kraftwerksnummer_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -137,7 +121,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -146,13 +129,11 @@ fields:
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true
   - name: Nettonennleistung
     index: true
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true # sometimes missing
   - name: AnschlussAnHoechstOderHochSpannung
     xsd: boolean
     psql: boolean
@@ -208,7 +189,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: Technologie
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer

--- a/spec/EinheitenGasErzeuger.yaml
+++ b/spec/EinheitenGasErzeuger.yaml
@@ -6,16 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -23,12 +19,10 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
   - name: AnlagenbetreiberMastrNummer
-    mandatory: true # sometimes missing
     references:
       table: Marktakteur
       column: MastrNummer
@@ -36,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -51,7 +44,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -60,9 +52,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -72,7 +62,6 @@ fields:
     sqlite: integer
   - name: Adresszusatz
   - name: Ort
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -95,7 +84,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -115,7 +103,6 @@ fields:
     xsd: date
     psql: date
   - name: NameGaserzeugungseinheit
-    mandatory: true
   - name: Technologie
     xsd: nonNegativeInteger
     psql: integer
@@ -127,9 +114,7 @@ fields:
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true
   - name: SpeicherMaStRNummer
-    mandatory: true
       # TODO: Figure out what this is supposed to reference.
     #references:
     #  table: AnlagenGasSpeicher

--- a/spec/EinheitenGasSpeicher.yaml
+++ b/spec/EinheitenGasSpeicher.yaml
@@ -6,16 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -23,12 +19,10 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
   - name: AnlagenbetreiberMastrNummer
-    mandatory: true # sometimes missing
     references:
       table: Marktakteur
       column: MastrNummer
@@ -36,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -51,7 +44,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -60,9 +52,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -72,7 +62,6 @@ fields:
     sqlite: integer
   - name: Adresszusatz
   - name: Ort
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -95,7 +84,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -115,9 +103,7 @@ fields:
     xsd: date
     psql: date
   - name: NameGasspeicher
-    mandatory: true
   - name: Speicherart
-    mandatory: true
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -141,12 +127,10 @@ fields:
     psql: real
     sqlite: real
   - name: Weic
-    mandatory: true
   - name: Weic_Na # docs say Weic
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: GenMastrNummer
     references:
       table: EinheitGenehmigung

--- a/spec/EinheitenGasverbraucher.yaml
+++ b/spec/EinheitenGasverbraucher.yaml
@@ -6,16 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -23,12 +19,10 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
   - name: AnlagenbetreiberMastrNummer
-    mandatory: true # sometimes missing
     references:
       table: Marktakteur
       column: MastrNummer
@@ -36,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -51,7 +44,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -60,9 +52,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -72,7 +62,6 @@ fields:
     sqlite: integer
   - name: Adresszusatz
   - name: Ort
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -95,7 +84,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -115,7 +103,6 @@ fields:
     xsd: date
     psql: date
   - name: NameGasverbrauchsseinheit
-    mandatory: true
   - name: MaximaleGasbezugsleistung
     xsd: decimal
     psql: real

--- a/spec/EinheitenGenehmigung.yaml
+++ b/spec/EinheitenGenehmigung.yaml
@@ -6,19 +6,15 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: GenMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: Art
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -27,20 +23,16 @@ fields:
     xsd: date
     psql: date
     sqlite: text
-    mandatory: true
   - name: Behoerde
-    mandatory: true
   - name: Aktenzeichen
   - name: Frist
     xsd: date
     psql: date
     sqlite: text
-    mandatory: true
   - name: Frist_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: WasserrechtsNummer
   - name: WasserrechtAblaufdatum
     xsd: date

--- a/spec/EinheitenGeoSolarthermieGrubenKlaerschlammDruckentspannung.yaml
+++ b/spec/EinheitenGeoSolarthermieGrubenKlaerschlammDruckentspannung.yaml
@@ -6,16 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -23,7 +19,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
@@ -35,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -50,7 +44,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true # sometimes missing
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -59,9 +52,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -71,7 +62,6 @@ fields:
     sqlite: integer
   - name: Adresszusatz
   - name: Ort
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -94,7 +84,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -114,19 +103,14 @@ fields:
     xsd: date
     psql: date
   - name: NameStromerzeugungseinheit
-    mandatory: true
   - name: Weic
-    mandatory: true # sometimes missing
   - name: Weic_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: WeicDisplayName
   - name: Kraftwerksnummer
-    mandatory: true # sometimes missing
   - name: Kraftwerksnummer_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -134,7 +118,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -142,12 +125,10 @@ fields:
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true
   - name: Nettonennleistung
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true # sometimes missing
   - name: AnschlussAnHoechstOderHochSpannung
     xsd: boolean
     psql: boolean

--- a/spec/EinheitenKernkraft.yaml
+++ b/spec/EinheitenKernkraft.yaml
@@ -6,16 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -23,12 +19,10 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
   - name: AnlagenbetreiberMastrNummer
-    mandatory: true
     references:
       table: Marktakteur
       column: MastrNummer
@@ -36,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -51,7 +44,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true # sometimes missing
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -60,9 +52,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -72,7 +62,6 @@ fields:
     sqlite: integer
   - name: Adresszusatz
   - name: Ort
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -95,7 +84,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -115,19 +103,14 @@ fields:
     xsd: date
     psql: date
   - name: NameStromerzeugungseinheit
-    mandatory: true
   - name: Weic
-    mandatory: true # sometimes missing
   - name: Weic_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: WeicDisplayName
   - name: Kraftwerksnummer
-    mandatory: true # sometimes missing
   - name: Kraftwerksnummer_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -135,7 +118,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -143,12 +125,10 @@ fields:
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true
   - name: Nettonennleistung
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true # sometimes missing
   - name: AnschlussAnHoechstOderHochSpannung
     xsd: boolean
     psql: boolean
@@ -190,7 +170,6 @@ fields:
       table: EinheitGenehmigung
       column: GenMastrNummer
   - name: NameKraftwerk
-    mandatory: true
   - name: NameKraftwerksblock
   - name: Technologie
     xsd: nonNegativeInteger

--- a/spec/EinheitenSolar.yaml
+++ b/spec/EinheitenSolar.yaml
@@ -6,14 +6,11 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
     references:
       table: Lokation
@@ -22,12 +19,10 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
   - name: AnlagenbetreiberMastrNummer
-    mandatory: true # sometimes missing
     references:
       table: Marktakteur
       column: MastrNummer
@@ -35,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -51,7 +45,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -60,9 +53,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -73,7 +64,6 @@ fields:
   - name: Adresszusatz
   - name: Ort
     index: true
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -97,7 +87,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -117,19 +106,14 @@ fields:
     xsd: date
     psql: date
   - name: NameStromerzeugungseinheit
-    mandatory: true
   - name: Weic
-    mandatory: true # sometimes missing
   - name: Weic_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: WeicDisplayName
   - name: Kraftwerksnummer
-    mandatory: true # sometimes missing
   - name: Kraftwerksnummer_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -137,7 +121,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -146,13 +129,11 @@ fields:
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true
   - name: Nettonennleistung
     index: true
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true
   - name: AnschlussAnHoechstOderHochSpannung
     xsd: boolean
     psql: boolean
@@ -271,7 +252,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EegMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: AnlageEegSolar
       column: EegMaStRNummer

--- a/spec/EinheitenStromSpeicher.yaml
+++ b/spec/EinheitenStromSpeicher.yaml
@@ -6,16 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -23,12 +19,10 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
   - name: AnlagenbetreiberMastrNummer
-    mandatory: true # sometimes missing
     references:
       table: Marktakteur
       column: MastrNummer
@@ -36,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -52,7 +45,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -61,9 +53,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -74,7 +64,6 @@ fields:
   - name: Adresszusatz
   - name: Ort
     index: true
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -98,7 +87,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -118,19 +106,14 @@ fields:
     xsd: date
     psql: date
   - name: NameStromerzeugungseinheit
-    mandatory: true
   - name: Weic
-    mandatory: true # sometimes missing
   - name: Weic_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: WeicDisplayName
   - name: Kraftwerksnummer
-    mandatory: true # sometimes missing
   - name: Kraftwerksnummer_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -138,7 +121,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -147,13 +129,11 @@ fields:
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true
   - name: Nettonennleistung
     index: true
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true # sometimes missing
   - name: AnschlussAnHoechstOderHochSpannung
     xsd: boolean
     psql: boolean
@@ -252,7 +232,6 @@ fields:
       table: AnlageStromSpeicher
       column: MaStRNummer
   - name: EegMaStRNummer
-    mandatory: true # sometimes missing
   - name: EegAnlagentyp
     xsd: nonNegativeInteger
     psql: integer

--- a/spec/EinheitenStromVerbraucher.yaml
+++ b/spec/EinheitenStromVerbraucher.yaml
@@ -6,16 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -23,12 +19,10 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
   - name: AnlagenbetreiberMastrNummer
-    mandatory: true # sometimes missing
     references:
       table: Marktakteur
       column: MastrNummer
@@ -36,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -51,7 +44,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -60,9 +52,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -72,7 +62,6 @@ fields:
     sqlite: integer
   - name: Adresszusatz
   - name: Ort
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -95,7 +84,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer

--- a/spec/EinheitenVerbrennung.yaml
+++ b/spec/EinheitenVerbrennung.yaml
@@ -6,16 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -23,12 +19,10 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
   - name: AnlagenbetreiberMastrNummer
-    mandatory: true
     references:
       table: Marktakteur
       column: MastrNummer
@@ -36,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -52,7 +45,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true # sometimes missing
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -61,9 +53,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -74,7 +64,6 @@ fields:
   - name: Adresszusatz
   - name: Ort
     index: true
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -98,7 +87,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -118,19 +106,14 @@ fields:
     xsd: date
     psql: date
   - name: NameStromerzeugungseinheit
-    mandatory: true
   - name: Weic
-    mandatory: true # sometimes missing
   - name: Weic_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: WeicDisplayName
   - name: Kraftwerksnummer
-    mandatory: true # sometimes missing
   - name: Kraftwerksnummer_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -138,7 +121,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -147,13 +129,11 @@ fields:
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true
   - name: Nettonennleistung
     index: true
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true # sometimes missing
   - name: AnschlussAnHoechstOderHochSpannung
     xsd: boolean
     psql: boolean
@@ -195,18 +175,15 @@ fields:
       table: EinheitGenehmigung
       column: GenMastrNummer
   - name: NameKraftwerk
-    mandatory: true
   - name: NameKraftwerksblock
   - name: DatumBaubeginn
     xsd: date
     psql: date
   - name: AnzeigeEinerStilllegung
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: ArtDerStilllegung
-    mandatory: true
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -232,7 +209,6 @@ fields:
     xsd: date
     psql: date
   - name: Hauptbrennstoff
-    mandatory: true
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -240,7 +216,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: WeitererHauptbrennstoff
-    mandatory: true
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -248,7 +223,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: WeitereBrennstoffe # docs say this is an int, but it's a list of strings
-    mandatory: true
   - name: BestandteilGrenzkraftwerk
     xsd: boolean
     psql: boolean

--- a/spec/EinheitenWasser.yaml
+++ b/spec/EinheitenWasser.yaml
@@ -6,16 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -23,12 +19,10 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
   - name: AnlagenbetreiberMastrNummer
-    mandatory: true # sometimes missing
     references:
       table: Marktakteur
       column: MastrNummer
@@ -36,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -52,7 +45,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -61,9 +53,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -74,7 +64,6 @@ fields:
   - name: Adresszusatz
   - name: Ort
     index: true
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -98,7 +87,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -118,19 +106,14 @@ fields:
     xsd: date
     psql: date
   - name: NameStromerzeugungseinheit
-    mandatory: true
   - name: Weic
-    mandatory: true # sometimes missing
   - name: Weic_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: WeicDisplayName
   - name: Kraftwerksnummer
-    mandatory: true # sometimes missing
   - name: Kraftwerksnummer_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -138,7 +121,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -147,13 +129,11 @@ fields:
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true
   - name: Nettonennleistung
     index: true
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true # sometimes missing
   - name: AnschlussAnHoechstOderHochSpannung
     xsd: boolean
     psql: boolean
@@ -195,7 +175,6 @@ fields:
       table: EinheitGenehmigung
       column: GenMastrNummer
   - name: NameKraftwerk
-    #mandatory: true
   - name: ArtDerWasserkraftanlage
     xsd: nonNegativeInteger
     psql: integer
@@ -207,7 +186,6 @@ fields:
     xsd: boolean
     psql: boolean
     sqlite: integer
-    #mandatory: true
   - name: ArtDerStilllegung
     xsd: nonNegativeInteger
     psql: integer
@@ -219,12 +197,10 @@ fields:
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    #mandatory: true
   - name: MinderungStromerzeugung
     xsd: boolean
     psql: boolean
     sqlite: integer
-    #mandatory: true
   - name: BestandteilGrenzkraftwerk
     xsd: boolean
     psql: boolean
@@ -241,7 +217,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EegMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: AnlageEegWasser
       column: EegMaStRNummer

--- a/spec/EinheitenWind.yaml
+++ b/spec/EinheitenWind.yaml
@@ -6,16 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: EinheitMastrNummer
-    mandatory: true
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
     sqlite: text
-    mandatory: true
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -23,12 +19,10 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: NetzbetreiberpruefungDatum
     xsd: date
     psql: date
   - name: AnlagenbetreiberMastrNummer
-    mandatory: true # sometimes missing
     references:
       table: Marktakteur
       column: MastrNummer
@@ -36,7 +30,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -52,7 +45,6 @@ fields:
   - name: Gemeinde
   - name: Gemeindeschluessel
   - name: Postleitzahl
-    mandatory: true # sometimes missing
   - name: Gemarkung
   - name: FlurFlurstuecknummern
   - name: Strasse
@@ -61,9 +53,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -74,7 +64,6 @@ fields:
   - name: Adresszusatz
   - name: Ort
     index: true
-    mandatory: true # sometimes missing
   - name: Laengengrad
     xsd: decimal
     psql: real
@@ -98,7 +87,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: EinheitBetriebsstatus
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -118,19 +106,14 @@ fields:
     xsd: date
     psql: date
   - name: NameStromerzeugungseinheit
-    mandatory: true
   - name: Weic
-    mandatory: true # sometimes missing
   - name: Weic_nv
     xsd: boolean
     psql: boolean
     sqlite: integer
-    mandatory: true
   - name: WeicDisplayName
   - name: Kraftwerksnummer
-    mandatory: true # sometimes missing
   - name: Kraftwerksnummer_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -138,7 +121,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -147,13 +129,11 @@ fields:
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true
   - name: Nettonennleistung
     index: true
     xsd: decimal
     psql: real
     sqlite: real
-    mandatory: true
   - name: AnschlussAnHoechstOderHochSpannung
     xsd: boolean
     psql: boolean
@@ -195,9 +175,7 @@ fields:
       table: EinheitGenehmigung
       column: GenMastrNummer
   - name: NameWindpark
-    mandatory: true # sometimes missing
   - name: Lage
-    mandatory: true
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -240,14 +218,11 @@ fields:
       table: Katalogwert
       column: Id
   - name: Typenbezeichnung
-    mandatory: true # sometimes missing
   - name: Nabenhoehe
-    mandatory: true # sometimes missing
     xsd: decimal
     psql: real
     sqlite: real
   - name: Rotordurchmesser
-    mandatory: true # sometimes missing
     xsd: decimal
     psql: real
     sqlite: real
@@ -256,7 +231,6 @@ fields:
     psql: boolean
     sqlite: integer
   - name: AuflageAbschaltungLeistungsbegrenzung
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -285,17 +259,14 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Wassertiefe
-    mandatory: true # sometimes missing
     xsd: decimal
     psql: real
     sqlite: real
   - name: Kuestenentfernung
-    mandatory: true # sometimes missing
     xsd: decimal
     psql: real
     sqlite: real
   - name: EegMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: AnlageEegWind
       column: EegMaStRNummer

--- a/spec/Katalogkategorien.yaml
+++ b/spec/Katalogkategorien.yaml
@@ -7,12 +7,9 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: Id
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: Name
-    mandatory: true
 ---

--- a/spec/Katalogwerte.yaml
+++ b/spec/Katalogwerte.yaml
@@ -7,19 +7,15 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: Id
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
   - name: Wert
-    mandatory: true
   - name: KatalogKategorieId
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogkategorie
       column: Id

--- a/spec/Lokationen.yaml
+++ b/spec/Lokationen.yaml
@@ -6,15 +6,12 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: DatumLetzteAktualisierung
     xsd: dateTime
     psql: timestamp
   - name: MastrNummer
-    mandatory: true
   - name: NameDerTechnischenLokation
   - name: Lokationtyp
-    mandatory: true
   - name: VerknuepfteEinheitenMaStRNummern
   - name: NetzanschlusspunkteMaStRNummern
 ---

--- a/spec/Marktakteure.yaml
+++ b/spec/Marktakteure.yaml
@@ -6,11 +6,8 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: MastrNummer
-    mandatory: true
   - name: DatumLetzeAktualisierung
-    mandatory: true # sometimes missing
     xsd: dateTime
     psql: timestamp
     sqlite: text
@@ -19,7 +16,6 @@ fields:
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
-    mandatory: true
     references:
       table: Katalogwert
       column: Id
@@ -29,7 +25,6 @@ fields:
     index: true
   - name: Marktfunktion
     index: true
-    mandatory: true
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
@@ -53,9 +48,7 @@ fields:
   - name: Region
   - name: Strasse
   - name: Hausnummer
-    mandatory: true # sometimes missing
   - name: Hausnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -74,30 +67,22 @@ fields:
   - name: Netz
   - name: Nuts2
   - name: Email
-    mandatory: true # sometimes missing
   - name: Telefon
-    mandatory: true # sometimes missing
   - name: Fax
-    mandatory: true # sometimes missing
   - name: Fax_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: Webseite
-    mandatory: true # sometimes missing
   - name: Webseite_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: Registergericht
-    mandatory: true # sometimes missing
     xsd: nonNegativeInteger
     psql: integer
     sqlite: integer
   - name: Registergericht_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -107,9 +92,7 @@ fields:
     psql: boolean
     sqlite: integer
   - name: Registernummer
-    mandatory: true # sometimes missing
   - name: Registernummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
@@ -124,34 +107,26 @@ fields:
     psql: date
     sqlite: text
   - name: AcerCode
-    mandatory: true # sometimes missing
   - name: AcerCode_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: Umsatzsteueridentifikationsnummer
-    mandatory: true # sometimes missing
   - name: Umsatzsteueridentifikationsnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: Taetigkeitsende
     index: true
-    mandatory: true # sometimes missing
     xsd: date
     psql: date
     sqlite: text
   - name: Taetigkeitsende_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: BundesnetzagenturBetriebsnummer
-    mandatory: true # sometimes missing
   - name: BundesnetzagenturBetriebsnummer_nv
-    mandatory: true # sometimes missing
     xsd: boolean
     psql: boolean
     sqlite: integer

--- a/spec/Marktrollen.yaml
+++ b/spec/Marktrollen.yaml
@@ -6,33 +6,25 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: MarktakteurMastrNummer
-    mandatory: true
     references:
       table: Marktakteur
       column: Id
   - name: DatumLetzteAktualisierung
-    mandatory: true
     xsd: dateTime
     psql: timestamp
     sqlite: text
   - name: MastrNummer
-    mandatory: true
   - name: Marktrolle
-    mandatory: true
   - name: BundesnetzagenturBetriebsnummer
   - name: BundesnetzagenturBetriebsnummer_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: Marktpartneridentifikationsnummer
   - name: Marktpartneridentifikationsnummer_nv
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: KontaktdatenMarktrolle
-    mandatory: true
 ---

--- a/spec/Netzanschlusspunkte.yaml
+++ b/spec/Netzanschlusspunkte.yaml
@@ -6,17 +6,13 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: NetzanschlusspunktMastrNummer
-    mandatory: true
   - name: NetzanschlusspunktBezeichnung
   - name: LetzteAenderung
-    mandatory: true
     xsd: dateTime
     psql: timestamp
     sqlite: text
   - name: LokationMaStRNummer
-    mandatory: true # sometimes missing
     references:
       table: Lokation
       column: MastrNummer
@@ -78,7 +74,6 @@ fields:
       table: Katalogwert
       column: Id
   - name: NetzMaStRNummer
-    mandatory: true
     references:
       table: Netz
       column: MastrNummer

--- a/spec/Netze.yaml
+++ b/spec/Netze.yaml
@@ -6,14 +6,11 @@ fields:
   # defaults:
   #   xsd: string
   #   sqlite: text
-  #   mandatory: false
   - name: DatumLetzteAktualisierung
-    mandatory: true
     xsd: dateTime
     psql: timestamp
     sqlite: text
   - name: MastrNummer
-    mandatory: true
   - name: Sparte
     xsd: nonNegativeInteger
     psql: integer
@@ -22,17 +19,14 @@ fields:
       table: Katalogwert
       column: Id
   - name: KundenAngeschlossen
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: GeschlossenesVerteilnetz
-    mandatory: true
     xsd: boolean
     psql: boolean
     sqlite: integer
   - name: Bezeichnung
-    mandatory: true
   - name: Marktgebiet
     xsd: nonNegativeInteger
     psql: integer

--- a/web/template/Report.de.html.mustache
+++ b/web/template/Report.de.html.mustache
@@ -38,9 +38,8 @@
                     </thead>
                     <tbody>
                         {{#Files}}
-                        <tr class="{{#NumMissing}}failure{{/NumMissing}}{{^NumMissing}}{{#NumBroken}}failure{{/NumBroken}}{{/NumMissing}}">
+                        <tr class="{{#NumBroken}}failure{{/NumBroken}}">
                             <th scope="row">{{FileName}}</th>
-                            <td>{{#NumMissing}}<a href="#{{FileName}}--missing">{{NumMissing}}</a>{{/NumMissing}}{{^NumMissing}}—{{/NumMissing}}</td>
                             <td>{{#NumBroken}}<a href="#{{FileName}}--broken">{{NumBroken}}</a>{{/NumBroken}}{{^NumBroken}}—{{/NumBroken}}</td>
                         </tr>
                         {{/Files}}
@@ -50,32 +49,6 @@
         </article>
 
         {{#Files}}
-
-        {{#NumMissing}}
-        <article id="{{FileName}}--missing">
-            <header><strong>Fehlende Pflichtfelder</strong> in <code>{{FileName}}</code></header>
-            <figure>
-                <table role="grid">
-                    <thead>
-                        <tr>
-                            <th scope="col">Feldname</th>
-                            <th scope="col">Beispieleintrag</th>
-                            <th scope="col">Anzahl Fälle</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {{#Missing}}
-                        <tr>
-                            <th scope="row">{{FieldName}}</th>
-                            <td>{{Example}}</td>
-                            <td>{{NumOccurrences}}</td>
-                        </tr>
-                        {{/Missing}}                                                                                                                                     
-                    </tbody>
-                </table>
-            </figure>
-        </article>
-        {{/NumMissing}}
 
         {{#NumBroken}}
         <article id="{{FileName}}--broken">


### PR DESCRIPTION
Reply to my support question regarding what "Pflicht" actually means in the context of the field documentation:

> Die Angabe in der Spalte "Pflicht" in der Beschreibung des Exports gibt lediglich an, ob das Feld im Prozess der Registrierung ein Pflichtfeld ist.