### PR TITLE
Store compressed SQLite output in S3 bucket

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -120,6 +120,7 @@ jobs:
       run: |
         set -Eeuxo pipefail
 
+        # brotli: compact and fast compression. Keep the original file for the subsequent upload step.
         brotli --keep -4 --output=build/Marktstammdatenregister.db.br build/Marktstammdatenregister.db
         ls -lh build/Marktstammdatenregister.db.br
 
@@ -129,5 +130,6 @@ jobs:
       run: |
         set -Eeuxo pipefail
 
+        # gzip: less compact and slower than brotli, but more likely to already be installed on user's machines.
         pigz build/Marktstammdatenregister.db
         rclone copy --include Marktstammdatenregister.db.gz build/ 'wasabi:mastr-backup' --config build/rclone.conf

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -41,7 +41,7 @@ jobs:
         set -Eeuxo pipefail
 
         sudo apt-get -qq update
-        sudo apt-get -qq install axel brotli rclone
+        sudo apt-get -qq install axel brotli pigz rclone
 
         # ruby-mustache does not handle zero as an empty value for the purpose of {#IntValue}...{/IntValue} blocks.
         # https://github.com/cbroglie/mustache/releases
@@ -129,4 +129,5 @@ jobs:
       run: |
         set -Eeuxo pipefail
 
-        rclone copy --include Marktstammdatenregister.db build/ 'wasabi:mastr-backup' --config build/rclone.conf
+        pigz build/Marktstammdatenregister.db
+        rclone copy --include Marktstammdatenregister.db.gz build/ 'wasabi:mastr-backup' --config build/rclone.conf

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -120,7 +120,7 @@ jobs:
       run: |
         set -Eeuxo pipefail
 
-        brotli --rm -4 --output=build/Marktstammdatenregister.db.br build/Marktstammdatenregister.db
+        brotli --keep -4 --output=build/Marktstammdatenregister.db.br build/Marktstammdatenregister.db
         ls -lh build/Marktstammdatenregister.db.br
 
         flyctl deploy . --config build/fly.toml --dockerfile build/Dockerfile

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -124,3 +124,9 @@ jobs:
         ls -lh build/Marktstammdatenregister.db.br
 
         flyctl deploy . --config build/fly.toml --dockerfile build/Dockerfile
+
+    - name: Upload SQLite file to storage
+      run: |
+        set -Eeuxo pipefail
+
+        rclone copy --include Marktstammdatenregister.db build/ 'wasabi:mastr-backup' --config build/rclone.conf

--- a/build/rclone.conf
+++ b/build/rclone.conf
@@ -3,4 +3,3 @@ type = s3
 provider = Wasabi
 env_auth = true
 endpoint = s3.eu-central-1.wasabisys.com
-


### PR DESCRIPTION
This allows users to download the daily dump from https://s3.eu-central-1.wasabisys.com/mastr-backup/Marktstammdatenregister.db.gz.